### PR TITLE
Fixed a cut & paste problem in unit test.

### DIFF
--- a/reliable.c
+++ b/reliable.c
@@ -1815,7 +1815,7 @@ static void test_acks()
     uint8_t receiver_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( receiver_acked_packet, 0, sizeof( receiver_acked_packet ) );
     int receiver_num_acks;
-    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.sender, &receiver_num_acks );
+    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
     for ( i = 0; i < receiver_num_acks; ++i )
     {
         if ( receiver_acks[i] < TEST_ACKS_NUM_ITERATIONS )


### PR DESCRIPTION
test_acks() was not doing what it was supposed to because of this issue.