### PR TITLE
Eliminate redundant include and use strict prototypes

### DIFF
--- a/reliable.c
+++ b/reliable.c
@@ -27,7 +27,6 @@
 #include <memory.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 #include <stdarg.h>
 #include <inttypes.h>
 #include <float.h>
@@ -112,12 +111,12 @@ void reliable_default_free_function( void * context, void * pointer )
 
 // ------------------------------------------------------------------
 
-int reliable_init()
+int reliable_init(void)
 {
     return RELIABLE_OK;
 }
 
-void reliable_term()
+void reliable_term(void)
 {
 }
 

--- a/reliable.h
+++ b/reliable.h
@@ -75,9 +75,9 @@ extern "C" {
 #endif
 #endif
 
-int reliable_init();
+int reliable_init(void);
 
-void reliable_term();
+void reliable_term(void);
 
 struct reliable_config_t
 {


### PR DESCRIPTION
`include <stdlib.h>` is duplicated.